### PR TITLE
Improve TLS configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,10 @@ language: python
 python: "2.7"
 before_install:
   - sudo apt-get update -qq
+  - sudo apt-get purge rabbitmq-server
 install:
   # Install Ansible.
-  - pip install ansible
+  - pip install ansible==2.3.2.0
 
   # Create an inventory file for testing.
   - "printf 'rabbit-standalone ansible_ssh_host=localhost' > inventory"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -23,6 +23,13 @@ rabbitmq_server_key                           : "files/rabbitmq_server_key.pem"
 rabbitmq_server_cert                          : "files/rabbitmq_server_cert.pem"
 rabbitmq_ssl                                  : true
 
+# SSL Configuration
+rabbitmq_copy_ssl_files                       : true
+rabbitmq_use_ssl_cn_as_login                  : false
+
+# Authentication mechanisms (not set by default)
+# rabbitmq_auth_mechanisms                    : [ 'PLAIN', 'AMQPLAIN' ]
+
 ## Optional logging
 ##  none, error, warnings, info, debug
 # rabbitmq_log_level                           :

--- a/tasks/configuration.yml
+++ b/tasks/configuration.yml
@@ -7,7 +7,7 @@
     group="rabbitmq"
     mode=0750
     state="directory"
-  when: rabbitmq_ssl
+  when: rabbitmq_ssl and rabbitmq_copy_ssl_files
 
 - name: configuration | copy the ssl certificates
   copy:
@@ -24,7 +24,7 @@
       dest: "{{ rabbitmq_conf_ssl_options_keyfile }}"
     - src: "{{ rabbitmq_server_cert }}"
       dest: "{{ rabbitmq_conf_ssl_options_certfile }}"
-  when: rabbitmq_ssl
+  when: rabbitmq_ssl and rabbitmq_copy_ssl_files
 
 - name: configuration | generate the configuration of rabbitmq
   template:

--- a/tasks/federation.yml
+++ b/tasks/federation.yml
@@ -17,11 +17,12 @@
     name={{ item.name }}
     vhost={{ item.vhost | default('/', false) }}
     value=" {{ item.value }} "
-  with_items: rabbitmq_federation_configuration
+  with_items: "{{rabbitmq_federation_configuration}}"
 
 - name: get the version of rabbitmq
   shell: rabbitmqctl status | awk '{print $NF}'
   register: rabbitmq_version
+  changed_when: False
 
 # local-username is no longer required with 3.3.0
 # http://www.rabbitmq.com/release-notes/README-3.3.0.txt

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -10,11 +10,11 @@
 
 - include: users.yml
 
-- include: policy.yml
-  when: "rabbitmq_policy_configuration is defined"
-
 - include: federation.yml
   when: rabbitmq_federation
+
+- include: policy.yml
+  when: "rabbitmq_policy_configuration is defined"
 
 - block:
     - include: cluster/checks.yml

--- a/templates/rabbitmq.config.j2
+++ b/templates/rabbitmq.config.j2
@@ -24,6 +24,12 @@
     {tcp_listeners, []}{% if rabbitmq_ssl %},
 {% endif %}
 {% endif %}
+{% if rabbitmq_auth_mechanisms is defined %}
+    {auth_mechanisms, [ {% for authmech in rabbitmq_auth_mechanisms %}'{{authmech}}'{% if not loop.last %},{% endif %}{% endfor %} ]},
+{% endif %}
+{% if rabbitmq_use_ssl_cn_as_login %}
+    {ssl_cert_login_from, common_name},
+{% endif %}
 {% if rabbitmq_ssl %}
     {ssl_listeners, [{"{{ rabbitmq_conf_ssl_listeners_address }}", {{ rabbitmq_conf_ssl_listeners_port }}}]},
     {ssl_options, [

--- a/test/integration/cluster_1/cluster_1.retry
+++ b/test/integration/cluster_1/cluster_1.retry
@@ -1,1 +1,0 @@
-cluster-1-docker-u14

--- a/vagrant/test_standalone.yml
+++ b/vagrant/test_standalone.yml
@@ -2,10 +2,10 @@
 - shell: netstat -an | grep 0.0.0.0:5672.*LISTEN
   register: test_result
   ignore_errors: True
-- name: rabbitmq should not be listenning to the unencrypted port
+- name: rabbitmq should be listenning to the unencrypted port
   assert:
     that:
-      - test_result|failed
+      - test_result|success
 
 - shell: netstat -an | grep 0.0.0.0:5671.*LISTEN
   register: test_result


### PR DESCRIPTION
This pull request implements following:

1) Added an option not to copy certificates from local machine if they are managed by something else, i.e. another Ansible role. Original behavior is preserved as default.
2) Configuration options to allow TLS CN authentication instead of PLAIN are added.
3) Some minor fixes to role.